### PR TITLE
Add empty test files

### DIFF
--- a/auth/authImpl_test.go
+++ b/auth/authImpl_test.go
@@ -1,0 +1,1 @@
+package auth

--- a/auth/authImpl_test.go
+++ b/auth/authImpl_test.go
@@ -1,1 +1,117 @@
 package auth
+
+import (
+	"testing"
+	"github.com/stretchr/testify/assert"
+	"crypto/rsa"
+	"crypto/rand"
+	"github.com/it-chain/heimdall/key"
+	"crypto/sha512"
+	"crypto/elliptic"
+	"crypto/ecdsa"
+)
+
+func TestNewAuth(t *testing.T) {
+
+	authManager, err := NewAuth()
+	assert.NoError(t, err)
+	assert.NotNil(t, authManager)
+
+}
+
+func TestAuth_RSASignVerify(t *testing.T) {
+
+	var rsaKeyBits = 4096
+
+	generatedKey, err := rsa.GenerateKey(rand.Reader, rsaKeyBits)
+	assert.NoError(t, err)
+	assert.NotNil(t, generatedKey)
+
+	pri := &key.RSAPrivateKey{generatedKey, rsaKeyBits}
+	assert.NotNil(t, pri)
+
+	pub, err := pri.PublicKey()
+	assert.NoError(t, err)
+	assert.NotNil(t, pub)
+
+	rawData := []byte("RSA Sign test data!!!")
+
+	hash := sha512.New()
+	hash.Write(rawData)
+	digest := hash.Sum(nil)
+
+	// hash for generating wrong type of digest
+	hash = sha512.New512_256()
+	hash.Write(rawData)
+	wrongDigest := hash.Sum(nil)
+
+	authManager, err := NewAuth()
+	assert.NoError(t, err)
+	assert.NotNil(t, authManager)
+
+	signature, err := authManager.Sign(pri, digest, EQUAL_SHA512.SignerOptsToPSSOptions())
+	assert.NoError(t, err)
+	assert.NotNil(t, signature)
+
+	// normal case
+	ok, err := authManager.Verify(pub, signature, digest, EQUAL_SHA512.SignerOptsToPSSOptions())
+	assert.NoError(t, err)
+	assert.True(t, ok)
+
+	// public key missing case
+	_, err = authManager.Verify(nil, signature, digest, EQUAL_SHA512.SignerOptsToPSSOptions())
+	assert.Error(t, err)
+
+	// signature missing case
+	_, err = authManager.Verify(pub, nil, digest, EQUAL_SHA512.SignerOptsToPSSOptions())
+	assert.Error(t, err)
+
+	// digest missing case
+	_, err = authManager.Verify(pub, signature, nil, EQUAL_SHA512.SignerOptsToPSSOptions())
+	assert.Error(t, err)
+
+	// passing wrong digest case
+	_, err = authManager.Verify(pub, signature, wrongDigest, EQUAL_SHA256.SignerOptsToPSSOptions())
+	assert.Error(t, err)
+
+	// passing wrong signer option case
+	ok, err = authManager.Verify(pub, signature, digest, EQUAL_SHA256.SignerOptsToPSSOptions())
+	assert.Error(t, err)
+	assert.False(t, ok)
+
+}
+
+func TestAuth_ECDSASignVerify(t *testing.T) {
+
+	var ecdsaCurve = elliptic.P521()
+
+	generatedKey, err := ecdsa.GenerateKey(ecdsaCurve, rand.Reader)
+	assert.NoError(t, err)
+	assert.NotNil(t, generatedKey)
+
+	pri := &key.ECDSAPrivateKey{PrivKey:generatedKey}
+	assert.NotNil(t, pri)
+
+	pub, err := pri.PublicKey()
+	assert.NoError(t, err)
+	assert.NotNil(t, pub)
+
+	rawData := []byte("ECDSA Sign test data!!!")
+
+	hash := sha512.New()
+	hash.Write(rawData)
+	digest := hash.Sum(nil)
+
+	authManager, err := NewAuth()
+	assert.NoError(t, err)
+	assert.NotNil(t, authManager)
+
+	signature, err := authManager.Sign(pri, digest, nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, signature)
+
+	ok, err := authManager.Verify(pub, signature, digest, nil)
+	assert.NoError(t, err)
+	assert.True(t, ok)
+
+}

--- a/auth/ecdsa_test.go
+++ b/auth/ecdsa_test.go
@@ -1,0 +1,1 @@
+package auth

--- a/auth/rsa_test.go
+++ b/auth/rsa_test.go
@@ -1,0 +1,1 @@
+package auth

--- a/hashing/hashManagerImpl_test.go
+++ b/hashing/hashManagerImpl_test.go
@@ -1,0 +1,1 @@
+package hashing

--- a/key/ecdsa_test.go
+++ b/key/ecdsa_test.go
@@ -1,0 +1,1 @@
+package key

--- a/key/keyLoader.go
+++ b/key/keyLoader.go
@@ -51,7 +51,7 @@ func (loader *keyLoader) Load() (pri PriKey, pub PubKey, err error) {
 
 				switch key.(type) {
 				case *rsa.PrivateKey:
-					pri = &RSAPrivateKey{PrivKey: key.(*rsa.PrivateKey), bits: KeyGenOptsToRSABits(keyInfos.keyGenOpts)}
+					pri = &RSAPrivateKey{PrivKey: key.(*rsa.PrivateKey), Bits: KeyGenOptsToRSABits(keyInfos.keyGenOpts)}
 				case *ecdsa.PrivateKey:
 					pri = &ECDSAPrivateKey{PrivKey: key.(*ecdsa.PrivateKey)}
 				default:
@@ -66,7 +66,7 @@ func (loader *keyLoader) Load() (pri PriKey, pub PubKey, err error) {
 
 				switch key.(type) {
 				case *rsa.PublicKey:
-					pub = &RSAPublicKey{PubKey: key.(*rsa.PublicKey), bits: KeyGenOptsToRSABits(keyInfos.keyGenOpts)}
+					pub = &RSAPublicKey{PubKey: key.(*rsa.PublicKey), Bits: KeyGenOptsToRSABits(keyInfos.keyGenOpts)}
 				case *ecdsa.PublicKey:
 					pub = &ECDSAPublicKey{key.(*ecdsa.PublicKey)}
 				default:

--- a/key/keyLoader_test.go
+++ b/key/keyLoader_test.go
@@ -1,0 +1,1 @@
+package key

--- a/key/keyManager_test.go
+++ b/key/keyManager_test.go
@@ -1,0 +1,1 @@
+package key

--- a/key/keyStorer_test.go
+++ b/key/keyStorer_test.go
@@ -1,0 +1,1 @@
+package key

--- a/key/keyUtils_test.go
+++ b/key/keyUtils_test.go
@@ -1,0 +1,1 @@
+package key

--- a/key/rsa.go
+++ b/key/rsa.go
@@ -32,7 +32,7 @@ func (keygen *RSAKeyGenerator) Generate(opts KeyGenOpts) (pri PriKey, pub PubKey
 		return nil, nil, fmt.Errorf("Failed to generate RSA key : %s", err)
 	}
 
-	pri = &RSAPrivateKey{PrivKey: generatedKey, bits: keygen.bits}
+	pri = &RSAPrivateKey{PrivKey: generatedKey, Bits: keygen.bits}
 	pub, err = pri.(*RSAPrivateKey).PublicKey()
 	if err != nil {
 		return nil, nil, err
@@ -48,10 +48,10 @@ type rsaKeyMarshalOpt struct {
 	E int
 }
 
-// RSAPrivateKey contains private key of ECDSA.
+// RSAPrivateKey contains private key of RSA.
 type RSAPrivateKey struct {
 	PrivKey *rsa.PrivateKey
-	bits    int
+	Bits    int
 }
 
 // SKI provides name of file that will be store a RSA private key.
@@ -73,12 +73,12 @@ func (key *RSAPrivateKey) SKI() (ski []byte) {
 
 // Algorithm returns key generation option of RSA.
 func (key *RSAPrivateKey) Algorithm() KeyGenOpts {
-	return RSABitsToKeyGenOpts(key.bits)
+	return RSABitsToKeyGenOpts(key.Bits)
 }
 
 // PublicKey returns RSA public key of key pair.
 func (key *RSAPrivateKey) PublicKey() (pub PubKey, err error) {
-	return &RSAPublicKey{PubKey: &key.PrivKey.PublicKey, bits: key.bits}, nil
+	return &RSAPublicKey{PubKey: &key.PrivKey.PublicKey, Bits: key.Bits}, nil
 }
 
 // ToPEM makes a RSA private key to PEM format.
@@ -101,7 +101,7 @@ func (key *RSAPrivateKey) Type() KeyType {
 // RSAPublicKey contains components of a public key.
 type RSAPublicKey struct {
 	PubKey *rsa.PublicKey
-	bits   int
+	Bits   int
 }
 
 // SKI provides name of file that will be store a RSA public key.
@@ -122,7 +122,7 @@ func (key *RSAPublicKey) SKI() (ski []byte) {
 
 // Algorithm returns RSA public key generation option.
 func (key *RSAPublicKey) Algorithm() KeyGenOpts {
-	return RSABitsToKeyGenOpts(key.bits)
+	return RSABitsToKeyGenOpts(key.Bits)
 }
 
 // ToPEM makes a RSA public key to PEM format.

--- a/key/rsa_test.go
+++ b/key/rsa_test.go
@@ -1,0 +1,1 @@
+package key


### PR DESCRIPTION
- 빈 테스트 파일들 추가함
- `authImpl`에 대한 테스트를 일부 진행함.
- `RSAPrivateKey`, `RSAPublicKey`의 `bits` 속성을 외부에서도 사용할 수 있도록 `Bits` 로 변경함.