### PR TITLE
README 수정입니다.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ keyManager, err := NewKeyManager(".myKeys")
 // Generate a pair of key with RSA Algorithm
 priv, pub, err := keyManager.GenerateKey(key.RSA4096)
 
+// If a pair of key is already exist, you can get key from memory or from file
+priv, pub, err = keyManager.GetKey()
+
 sampleData = []byte("This is the data will be transmitted.")
 
 hashManager, err := hashing.NewHashManager()
@@ -41,13 +44,19 @@ digest, err := hashManager.Hash(sampleData, nil, hashing.SHA512)
 
 authManager, err := auth.NewAuth()
 
-// The option will be used in signing process in case of using RSA key
+// The option will be used in signing process of RSA-PSS algorithm for making EM(Encoded Message)
 signerOpts := auth.EQUAL_SHA256.SignerOptsToPSSOptions()
 
 // AuthManager make hashed-data(digest) to signature with the generated private key
 signature, err := authManager.Sign(priv, digest, signerOpts)
 
 /* --------- After data transmitted --------- */
+// Reconstruct public key from byte(PEM) formatted public key and store the key into keyManager
+// byteFormatPubKey is a public key that is in byte(PEM) format
+err := keyManager.ByteToKey(byteFormatPubKey, key.RSA4096, key.PUBLIC_KEY)
+
+// Get the reconstructed public key
+_, pub, err := keyManager.GetKey()
 
 // AuthManager verify that received data has any forgery during transmitting process
 ok, err := authManager.Verify(pub, signature, digest, signerOpts)
@@ -57,10 +66,10 @@ fmt.println(ok) // true
 
 ## Features 
 
-### Asymmetric key algorithms
+### Signature algorithms
 
-Currently, we support following asymmetric key generation algorithms with options to provide wide selection range.
-- [RSA](https://en.wikipedia.org/wiki/RSA) ( 1024 / 2048 / 4096 )
+Currently, we support following Signature algorithms with options to provide wide selection range of key length.
+- [RSASSA-PSS](https://tools.ietf.org/html/rfc4056) ( 1024 / 2048 / 4096 )
 - [ECDSA](https://en.wikipedia.org/wiki/ECDSA) ( 224 / 256 / 384 / 512 )
 
 ### Hash functions


### PR DESCRIPTION
Modify usage and features section in README.md file
- Modify usage section for adding ByteToKey function as a content
- Modify features section for correcting the name of signature algorithm

1) ByteToKey 기능 추가에 따라 ByteToKey, GetKey 기능들을 usage에 포함시켰습니다.
2) Heimdall에서 제공하는 features에서 키 생성 알고리즘보다는 서명 알고리즘이 좀 더 맞는 표현인 것 같아서 수정했습니다.
그리고 찾아보니 RSA 알고리즘은 그 자체로 서명 알고리즘은 아니고 RSA-PSS와 RSASSA-PSS 등의 서명 알고리즘이 있었고 저희가 사용하는 RSA 서명 알고리즘은 golang 라이브러리를 보니 RSASSA-PSS 였습니다. 
PSSOption의 사용 이유도 RSASSA-PSS에서 메시지 해싱 이후에 바로 서명(private key로 암호화)이 아니라 해싱된 메시지에 대해 Encoded Message라는 폼으로 한 번 더 마스크 씌우고 해싱 등.. 과정이 있더라고요 :)
