### PR TITLE
Issue #35/separate key from keymanager

### DIFF
--- a/key/keyManager.go
+++ b/key/keyManager.go
@@ -14,9 +14,6 @@ type KeyManager interface {
 	// RemoveKey removes key files.
 	RemoveKey() error
 
-	// Reconstruct key from bytes.
-	ByteToKey(byteKey []byte, keyGenOpt KeyGenOpts, keyType KeyType) (err error)
-
 	// GetPath returns path of key files
 	GetPath() string
 }

--- a/key/keyManagerImpl_test.go
+++ b/key/keyManagerImpl_test.go
@@ -52,23 +52,6 @@ func TestKeyManagerImpl_RemoveKey(t *testing.T) {
 	defer os.RemoveAll("./.testKeys")
 }
 
-func TestKeyManagerImpl_ByteToKey(t *testing.T) {
-	var keyGenOption = KeyGenOpts(RSA2048)
-
-	testKeyManager, _ := NewKeyManager("./.testKeys")
-	pri, pub, _ := testKeyManager.GenerateKey(keyGenOption)
-
-	priPEM, _ := pri.ToPEM()
-	pubPEM, _ := pub.ToPEM()
-
-	err := testKeyManager.ByteToKey(priPEM, keyGenOption, pri.Type())
-	assert.NoError(t, err)
-	err = testKeyManager.ByteToKey(pubPEM, keyGenOption, pub.Type())
-	assert.NoError(t, err)
-
-	defer os.RemoveAll("./.testKeys")
-}
-
 func TestKeyManagerImpl_GetPath(t *testing.T) {
 	testKeyManager, _ := NewKeyManager("./.testKeys")
 	originPath := "./.testKeys/.keys"

--- a/key/keyUtils.go
+++ b/key/keyUtils.go
@@ -11,7 +11,7 @@ import (
 )
 
 // PEMToPublicKey converts PEM to public key format.
-func PEMToPublicKey(data []byte) (interface{}, error) {
+func PEMToPublicKey(data []byte, keyGenOpt KeyGenOpts) (PubKey, error) {
 
 	if len(data) == 0 {
 		return nil, errors.New("Input data should not be NIL")
@@ -27,12 +27,17 @@ func PEMToPublicKey(data []byte) (interface{}, error) {
 		return nil, errors.New("Failed to convert PEM data to public key")
 	}
 
-	return key, nil
+	pub, err := MatchPublicKeyOpt(key, keyGenOpt)
+	if err != nil {
+		return nil, errors.New("Failed to convert the key type to matched public key")
+	}
+
+	return pub, nil
 
 }
 
 // PEMToPrivateKey converts PEM to private key format.
-func PEMToPrivateKey(data []byte) (interface{}, error) {
+func PEMToPrivateKey(data []byte, keyGenOpt KeyGenOpts) (PriKey, error) {
 	if len(data) == 0 {
 		return nil, errors.New("Input data should not be NIL")
 	}
@@ -47,7 +52,12 @@ func PEMToPrivateKey(data []byte) (interface{}, error) {
 		return nil, errors.New("Failed to convert PEM data to private key")
 	}
 
-	return key, nil
+	pri, err := MatchPrivateKeyOpt(key, keyGenOpt)
+	if err != nil {
+		return nil, errors.New("Failed to convert the key type to matched private key")
+	}
+
+	return pri, nil
 
 }
 
@@ -89,20 +99,6 @@ func DERToPrivateKey(data []byte) (interface{}, error) {
 
 }
 
-// MatchPrivateKeyOpt converts key interface type to private key type using key generation option.
-func MatchPrivateKeyOpt(key interface{}, keyGenOpt KeyGenOpts) (privateKey PriKey, err error) {
-	switch key.(type) {
-	case *rsa.PrivateKey:
-		pri := &RSAPrivateKey{PrivKey: key.(*rsa.PrivateKey), Bits: KeyGenOptsToRSABits(keyGenOpt)}
-		return pri, nil
-	case *ecdsa.PrivateKey:
-		pri := &ECDSAPrivateKey{PrivKey: key.(*ecdsa.PrivateKey)}
-		return pri, nil
-	default:
-		return nil, errors.New("no matched key generation option")
-	}
-}
-
 // MatchPublicKeyOpt converts key interface type to public key type using key generation option.
 func MatchPublicKeyOpt(key interface{}, keyGenOpt KeyGenOpts) (publicKey PubKey, err error) {
 	switch key.(type) {
@@ -112,6 +108,20 @@ func MatchPublicKeyOpt(key interface{}, keyGenOpt KeyGenOpts) (publicKey PubKey,
 	case *ecdsa.PublicKey:
 		pub := &ECDSAPublicKey{key.(*ecdsa.PublicKey)}
 		return pub, nil
+	default:
+		return nil, errors.New("no matched key generation option")
+	}
+}
+
+// MatchPrivateKeyOpt converts key interface type to private key type using key generation option.
+func MatchPrivateKeyOpt(key interface{}, keyGenOpt KeyGenOpts) (privateKey PriKey, err error) {
+	switch key.(type) {
+	case *rsa.PrivateKey:
+		pri := &RSAPrivateKey{PrivKey: key.(*rsa.PrivateKey), Bits: KeyGenOptsToRSABits(keyGenOpt)}
+		return pri, nil
+	case *ecdsa.PrivateKey:
+		pri := &ECDSAPrivateKey{PrivKey: key.(*ecdsa.PrivateKey)}
+		return pri, nil
 	default:
 		return nil, errors.New("no matched key generation option")
 	}

--- a/key/keyUtils_test.go
+++ b/key/keyUtils_test.go
@@ -18,7 +18,7 @@ func TestPEMToPrivateKey(t *testing.T) {
 
 	priPEM, _ := pri.ToPEM()
 
-	testPri, err := PEMToPrivateKey(priPEM)
+	testPri, err := PEMToPrivateKey(priPEM, keyGenOption)
 	assert.NotNil(t, testPri)
 	assert.NoError(t, err)
 
@@ -33,7 +33,7 @@ func TestPEMToPublicKey(t *testing.T) {
 
 	pubPEM, _ := pub.ToPEM()
 
-	testPub, err := PEMToPublicKey(pubPEM)
+	testPub, err := PEMToPublicKey(pubPEM, keyGenOption)
 	assert.NotNil(t, testPub)
 	assert.NoError(t, err)
 
@@ -80,7 +80,9 @@ func TestMatchPrivateKeyOpt(t *testing.T) {
 
 	priPEM, _ := pri.ToPEM()
 
-	testPri, _ := PEMToPrivateKey(priPEM)
+	block, _ := pem.Decode(priPEM)
+
+	testPri, _ := DERToPrivateKey(block.Bytes)
 
 	myPri, err := MatchPrivateKeyOpt(testPri, keyGenOption)
 	assert.NoError(t, err)
@@ -97,7 +99,9 @@ func TestMatchPublicKeyOpt(t *testing.T) {
 
 	pubPEM, _ := pub.ToPEM()
 
-	testPub, _ := PEMToPublicKey(pubPEM)
+	block, _ := pem.Decode(pubPEM)
+
+	testPub, _ := DERToPublicKey(block.Bytes)
 
 	myPub, err := MatchPublicKeyOpt(testPub, keyGenOption)
 	assert.NoError(t, err)

--- a/sample/heimdall-ecdsa-sample.go
+++ b/sample/heimdall-ecdsa-sample.go
@@ -37,12 +37,9 @@ func main() {
 	bytePubKey, err := pub.ToPEM()
 
 	// Reconstruct key pair from bytes to key.
-	err = keyManager.ByteToKey(bytePriKey, key.ECDSA384, key.PRIVATE_KEY)
-	err = keyManager.ByteToKey(bytePubKey, key.ECDSA384, key.PUBLIC_KEY)
+	recPri, err := key.PEMToPrivateKey(bytePriKey, key.ECDSA384)
+	recPub, err := key.PEMToPublicKey(bytePubKey, key.ECDSA384)
 	errorCheck(err)
-
-	// Get the reconstructed key pair.
-	recPri, recPub, err := keyManager.GetKey()
 
 	// Compare reconstructed key pair with original key pair.
 	if reflect.DeepEqual(pri, recPri) && reflect.DeepEqual(pub, recPub) {

--- a/sample/heimdall-rsa-sample.go
+++ b/sample/heimdall-rsa-sample.go
@@ -37,12 +37,9 @@ func main() {
 	bytePubKey, err := pub.ToPEM()
 
 	// Reconstruct key pair from bytes to key.
-	err = keyManager.ByteToKey(bytePriKey, key.RSA4096, key.PRIVATE_KEY)
-	err = keyManager.ByteToKey(bytePubKey, key.RSA4096, key.PUBLIC_KEY)
+	recPri, err := key.PEMToPrivateKey(bytePriKey, key.RSA4096)
+	recPub, err := key.PEMToPublicKey(bytePubKey, key.RSA4096)
 	errorCheck(err)
-
-	// Get the reconstructed key pair.
-	recPri, recPub, err := keyManager.GetKey()
 
 	// Compare reconstructed key pair with original key pair.
 	if reflect.DeepEqual(pri, recPri) && reflect.DeepEqual(pub, recPub) {


### PR DESCRIPTION
이슈에 정리한 사항들에 'key manager에서 key 제거' 부분이 빠져있어서 먼저 수정했습니다.

내용은.. 하다보니 커밋 단위가 너무 커져서 커밋 메시지를 잘 못 쓴것 같네요..
1) key manager에서 key 제거했습니다.
2) key를 반환해야하는 ByteToKey를 key manager에서 제거하고 keyUtils로 옮겼다가 PEMToPrivateKey, PEMToPublicKey로 대체가 가능해서 제거했습니다.

- ByteToKey에서 직접 키들을 반환하려고 하니.. ByteToKey는 return 키 데이터 타입 문제(key, PriKey, PubKey) 때문에 public key, private key로 쪼개려다가.. 기존 함수들로 대체가 가능해져서 제거했습니다.
- ByteToKey 함수를 위해 만들어둔 MatchPublicKeyOpt, MatchPrivateKeyOpt 함수들을 이용하면 PEMToPrivateKey, PEMToPublicKey로 ByteToKey를 대체할 수 있었습니다.

3) 2번의 수정을 적용했더니 keyloader쪽에서도 키 데이터 타입 때문에 문제가 좀 생겨서 loadKey 함수를 loadKeyBytes함수와 수정된 PEMToPrivateKey, PEMToPublicKey로 대체 했습니다.

4) 샘플 코드와 테스트 코드도 수정된 부분에 맞게 수정했습니다.
