### PR TITLE
Issue/68 - config 지원하도록 기능 수정

### DIFF
--- a/config.go
+++ b/config.go
@@ -119,11 +119,10 @@ func (conf *Config) initDefaultConfig() {
 	conf.kdf = "scrypt"
 	conf.sigAlgo = "ECDSA"
 	conf.encAlgo = "AES-CTR"
-	conf.kdfParams = make(map[string]string, 5)
+	conf.kdfParams = make(map[string]string, 3)
 	conf.kdfParams["n"] = ScryptN
 	conf.kdfParams["r"] = ScryptR
 	conf.kdfParams["p"] = ScryptP
-	conf.kdfParams["keyLen"] = string(conf.secLv)
 	conf.initBySecLv192()
 }
 
@@ -131,27 +130,27 @@ func (conf *Config) initDefaultConfig() {
 func (conf *Config) initBySecLv112() {
 	conf.hashOpt = SHA224
 	conf.curveOpt = SECP224R1
-	conf.encKeyLength = 112
+	conf.encKeyLength = int(112 / 8)
 }
 
 // initBySecLv128 sets hash type, elliptic curve type, key length for encryption corresponding to 128bits of security level.
 func (conf *Config) initBySecLv128() {
 	conf.hashOpt = SHA256
 	conf.curveOpt = SECP256R1
-	conf.encKeyLength = 128
+	conf.encKeyLength = int(128 / 8)
 }
 
 // initBySecLv192 sets hash type, elliptic curve type, key length for encryption corresponding to 192bits of security level.
 func (conf *Config) initBySecLv192() {
 	conf.hashOpt = SHA384
 	conf.curveOpt = SECP384R1
-	conf.encKeyLength = 192
+	conf.encKeyLength = int(192 / 8)
 }
 
 // initBySecLv256 sets hash type, elliptic curve type, key length for encryption corresponding to 256bits of security level.
 func (conf *Config) initBySecLv256() {
 	conf.hashOpt = SHA512
 	conf.curveOpt = SECP521R1
-	conf.encKeyLength = 256
+	conf.encKeyLength = int(256 / 8)
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -25,17 +25,15 @@ import (
 
 
 func TestNewConfig(t *testing.T) {
-	kdfParams := make(map[string]string, 5)
+	kdfParams := make(map[string]string, 3)
 	kdfParams["n"] = heimdall.ScryptN
 	kdfParams["r"] = heimdall.ScryptR
 	kdfParams["p"] = heimdall.ScryptP
-	kdfParams["keyLen"] = string(192)
 	conf, err := heimdall.NewConfig(192, heimdall.TestKeyDir, heimdall.TestCertDir, "AES-CTR", "ECDSA", "scrypt", kdfParams)
 	assert.NoError(t, err)
 	assert.NotNil(t, conf)
 
-	defaultConf := heimdall.NewDefaultConfig()
-	assert.Equal(t, conf, defaultConf)
+	assert.Equal(t, conf, heimdall.TestConf)
 }
 
 func TestNewDefaultConfig(t *testing.T) {

--- a/definition.go
+++ b/definition.go
@@ -33,6 +33,11 @@ import (
 // Key ID prefix
 const keyIDPrefix = "IT"
 
+// KDF functions
+const SCRYPT = "scrypt"
+const PBKDF2 = "pbkdf2"
+const BCRYPT = "bcrypt"
+
 // directories for test
 var WorkingDir, _ = os.Getwd()
 var RootDir = filepath.Dir(WorkingDir)
@@ -43,12 +48,19 @@ var TestCertDir = filepath.Join(WorkingDir, "./.testCerts")
 const TestCurveOpt = SECP256R1
 const TestHashOpt = SHA512
 
+
+// TestConf provides configuration struct using 192 bits of security level.
+var TestConf = NewDefaultConfig()
 // Note: salt have to be unique, so do not use this for real implementation.
 var TestSalt = []byte{0xc8, 0x28, 0xf2, 0x58, 0xa7, 0x6a, 0xad, 0x7b}
 var TestScrpytParams = map[string]string{
+	// N should highest power of 2 that key derived in 100ms.
 	"n" : ScryptN,
+	// R(blocksize parameter) : fine-tune sequential memory read size and performance. (8 is commonly used)
 	"r" : ScryptR,
+	// P(Parallelization parameter) : a positive integer satisfying p ≤ (232− 1) * hLen / MFLen.
 	"p" : ScryptP,
+	// keyLen : Desired length of key in bytes
 	"keyLen" : ScryptKeyLen,
 	"salt" : hex.EncodeToString([]byte("saltsalt")),
 }

--- a/keyDerivation.go
+++ b/keyDerivation.go
@@ -23,7 +23,6 @@ import (
 	"golang.org/x/crypto/scrypt"
 	"errors"
 	"strconv"
-	"encoding/hex"
 )
 
 const (
@@ -41,16 +40,10 @@ const (
 )
 
 // DeriveKeyFromPwd derives a key from input password.
-func DeriveKeyFromPwd(KDFName string, pwd []byte, KDFParams map[string]string) (dKey []byte, err error) {
+func DeriveKeyFromPwd(KDFName string, pwd []byte, salt []byte, keyLen int, KDFParams map[string]string) (dKey []byte, err error) {
 
-	if KDFName == "scrypt" {
+	if KDFName == SCRYPT {
 		// The params N, r, p are cost parameters, and 32768, 8, 1 are recommended parameters for interactive login as of 2017.
-
-		salt, err := hex.DecodeString(KDFParams["salt"])
-		if err != nil {
-			return nil, err
-		}
-
 		n, err := strconv.Atoi(KDFParams["n"])
 		if err != nil {
 			return nil, err
@@ -66,15 +59,11 @@ func DeriveKeyFromPwd(KDFName string, pwd []byte, KDFParams map[string]string) (
 			return nil, err
 		}
 
-		keyLen, err := strconv.Atoi(KDFParams["keyLen"])
-		if err != nil {
-			return nil, err
-		}
-
 		return scrypt.Key(pwd, salt, n, r, p, keyLen)
-	} else if KDFName == "pbkdf2"{
+
+	} else if KDFName == PBKDF2{
 		return nil, errors.New("invalid KDF - not supported")
-	} else if KDFName == "bcrypt" {
+	} else if KDFName == BCRYPT {
 		return nil, errors.New("invalid KDF - not supported")
 	} else {
 		return nil, errors.New("invalid KDF - not supported")

--- a/keyDerivation.go
+++ b/keyDerivation.go
@@ -25,19 +25,6 @@ import (
 	"strconv"
 )
 
-const (
-	KDFName = "scrypt"
-
-	// N should highest power of 2 that key derived in 100ms.
-	ScryptN = "32768" // 1 << 15 (2^15)
-	// Parallelization parameter; a positive integer satisfying p ≤ (232− 1) * hLen / MFLen.
-	ScryptP = "1"
-
-	// blocksize parameter : fine-tune sequential memory read size and performance. (8 is commonly used)
-	ScryptR = "8"
-	// Desired length of key in bytes
-	ScryptKeyLen = "32"
-)
 
 // DeriveKeyFromPwd derives a key from input password.
 func DeriveKeyFromPwd(KDFName string, pwd []byte, salt []byte, keyLen int, KDFParams map[string]string) (dKey []byte, err error) {

--- a/keyDerivation_test.go
+++ b/keyDerivation_test.go
@@ -20,21 +20,10 @@ package heimdall
 import (
 	"testing"
 	"github.com/stretchr/testify/assert"
-	"strconv"
 )
 
 func TestDeriveKeyFromPwd(t *testing.T) {
-	dKey, err := DeriveKeyFromPwd("scrypt", []byte("password"), TestScrpytParams)
+	dKey, err := DeriveKeyFromPwd(TestConf.kdf, []byte("password"), TestSalt, TestConf.encKeyLength, TestConf.kdfParams)
 	assert.NoError(t, err)
 	assert.NotNil(t, dKey)
-	keyLen, _ := strconv.Atoi(ScryptKeyLen)
-	assert.Len(t, dKey, keyLen)
-
-	dKey, err = DeriveKeyFromPwd("pbkdf2", []byte("password"), TestScrpytParams)
-	assert.Error(t, err)
-	assert.Nil(t, dKey)
-
-	dKey, err = DeriveKeyFromPwd("mykdf", []byte("password"), TestScrpytParams)
-	assert.Error(t, err)
-	assert.Nil(t, dKey)
 }

--- a/keyEncryption_test.go
+++ b/keyEncryption_test.go
@@ -24,7 +24,7 @@ import (
 
 func TestEncryptPriKey(t *testing.T) {
 	pri, _ := GenerateKey(TestCurveOpt)
-	dKey, _ := DeriveKeyFromPwd("scrypt", []byte("password"), TestScrpytParams)
+	dKey, _ := DeriveKeyFromPwd(TestConf.kdf, []byte("password"), TestSalt, TestConf.encKeyLength, TestConf.kdfParams)
 
 	encryptedKey, err := EncryptPriKey(pri, dKey)
 	assert.NoError(t, err)
@@ -33,7 +33,7 @@ func TestEncryptPriKey(t *testing.T) {
 
 func TestDecryptPriKey(t *testing.T) {
 	pri, _ := GenerateKey(TestCurveOpt)
-	dKey, _ := DeriveKeyFromPwd("scrypt", []byte("password"), TestScrpytParams)
+	dKey, _ := DeriveKeyFromPwd(TestConf.kdf, []byte("password"), TestSalt, TestConf.encKeyLength, TestConf.kdfParams)
 
 	encryptedKey, _ := EncryptPriKey(pri, dKey)
 

--- a/keystore_test.go
+++ b/keystore_test.go
@@ -24,16 +24,15 @@ import (
 )
 
 func TestNewKeyStore(t *testing.T) {
-	ks, err := NewKeyStore(TestKeyDir)
+	ks, err := NewKeyStore(TestConf.keyDirPath, TestConf.kdf, TestConf.kdfParams, TestConf.encAlgo, TestConf.encKeyLength)
 	assert.NoError(t, err)
 	assert.NotNil(t, ks)
-	assert.NotEmpty(t, ks.path)
 }
 
 func TestKeystore_StoreKey(t *testing.T) {
 	pri, _ := GenerateKey(TestCurveOpt)
 
-	ks, _ := NewKeyStore(TestKeyDir)
+	ks, _ := NewKeyStore(TestConf.keyDirPath, TestConf.kdf, TestConf.kdfParams, TestConf.encAlgo, TestConf.encKeyLength)
 	err := ks.StoreKey(pri, "password")
 	assert.NoError(t, err)
 
@@ -41,9 +40,9 @@ func TestKeystore_StoreKey(t *testing.T) {
 }
 
 func TestKeystore_LoadKey(t *testing.T) {
-	pri, _ := GenerateKey(TestCurveOpt)
+	pri, _ := GenerateKey(TestConf.curveOpt)
 
-	ks, _ := NewKeyStore(TestKeyDir)
+	ks, _ := NewKeyStore(TestConf.keyDirPath, TestConf.kdf, TestConf.kdfParams, TestConf.encAlgo, TestConf.encKeyLength)
 	_ = ks.StoreKey(pri, "password")
 
 	keyId := PubKeyToKeyID(&pri.PublicKey)


### PR DESCRIPTION
issue #68 config 지원하도록 기능 수정

주목적은 config로부터 설정 정보를 받아서 패스워드로부터 암호화 키를 유도하기 위한 키 유도 함수(KDF)에  parameter로 넣을 수 있도록 기존에 사용하던 scrypt(구현되어있는 KDF) 관련 상수들을 제거하고 관련 코드들을 수정했습니다.

머지되면 test code package 수정(heimdall -> heimdall_test) 다시 해서 올리겠습니다!