### PR TITLE
Issue/61 - test pacakge 변경 (heimdall -> heimdall_test)

### DIFF
--- a/auth_test.go
+++ b/auth_test.go
@@ -15,18 +15,19 @@
  *
  */
 
-package heimdall
+package heimdall_test
 
 import (
 	"testing"
 	"github.com/stretchr/testify/assert"
+	"github.com/it-chain/heimdall"
 )
 
 func TestSign(t *testing.T) {
 	msg := []byte("message for test")
-	pri, _ := GenerateKey(TestCurveOpt)
+	pri, _ := heimdall.GenerateKey(heimdall.TestCurveOpt)
 
-	signature, err := Sign(pri, msg, nil, TestHashOpt)
+	signature, err := heimdall.Sign(pri, msg, nil, heimdall.TestHashOpt)
 	assert.NoError(t, err)
 	assert.NotNil(t, signature)
 
@@ -35,33 +36,33 @@ func TestSign(t *testing.T) {
 
 func TestVerify(t *testing.T) {
 	msg := []byte("message for test")
-	pri, _ := GenerateKey(TestCurveOpt)
+	pri, _ := heimdall.GenerateKey(heimdall.TestCurveOpt)
 
-	signature, _ := Sign(pri, msg, nil, TestHashOpt)
+	signature, _ := heimdall.Sign(pri, msg, nil, heimdall.TestHashOpt)
 
-	valid, err := Verify(&pri.PublicKey, signature, msg, nil, TestHashOpt)
+	valid, err := heimdall.Verify(&pri.PublicKey, signature, msg, nil, heimdall.TestHashOpt)
 	assert.NoError(t, err)
 	assert.True(t, valid)
 
 	fakeMsg := append(msg, 1)
-	valid, err = Verify(&pri.PublicKey, signature, fakeMsg, nil, TestHashOpt)
+	valid, err = heimdall.Verify(&pri.PublicKey, signature, fakeMsg, nil, heimdall.TestHashOpt)
 	assert.NoError(t, err)
 	assert.False(t, valid)
 
-	fakeSig, _ := Sign(pri, fakeMsg, nil, TestHashOpt)
-	valid, err = Verify(&pri.PublicKey, fakeSig, msg, nil, TestHashOpt)
+	fakeSig, _ := heimdall.Sign(pri, fakeMsg, nil, heimdall.TestHashOpt)
+	valid, err = heimdall.Verify(&pri.PublicKey, fakeSig, msg, nil, heimdall.TestHashOpt)
 	assert.NoError(t, err)
 	assert.False(t, valid)
 }
 
 func TestVerifyWithCert(t *testing.T) {
 	msg := []byte("message for test")
-	pri, _ := GenerateKey(TestCurveOpt)
+	pri, _ := heimdall.GenerateKey(heimdall.TestCurveOpt)
 
-	signature, _ := Sign(pri, msg, nil, TestHashOpt)
-	cert, _ := PemToX509Cert([]byte(TestCertPemBytes))
+	signature, _ := heimdall.Sign(pri, msg, nil, heimdall.TestHashOpt)
+	cert, _ := heimdall.PemToX509Cert([]byte(heimdall.TestCertPemBytes))
 
-	valid, err := VerifyWithCert(cert, signature, msg, nil, TestHashOpt)
+	valid, err := heimdall.VerifyWithCert(cert, signature, msg, nil, heimdall.TestHashOpt)
 	assert.True(t, valid)
 	assert.NoError(t, err)
 }

--- a/config.go
+++ b/config.go
@@ -25,16 +25,16 @@ import (
 )
 
 type Config struct {
-	secLv int
-	keyDirPath string
-	certDirPath string
-	encAlgo string
-	sigAlgo string
-	kdf string
-	kdfParams map[string]string
-	curveOpt CurveOpts
-	hashOpt HashOpts
-	encKeyLength int
+	SecLv int
+	KeyDirPath string
+	CertDirPath string
+	EncAlgo string
+	SigAlgo string
+	Kdf string
+	KdfParams map[string]string
+	CurveOpt CurveOpts
+	HashOpt HashOpts
+	EncKeyLength int
 }
 
 // NewConfig makes configuration struct using entered parameters.
@@ -54,38 +54,38 @@ func (conf *Config) initConfig(secLv int, keyDirPath, certDirPath, encAlgo, sigA
 	if len(keyDirPath) == 0 {
 		return errors.New("invalid key directory path - empty")
 	}
-	conf.keyDirPath = keyDirPath
+	conf.KeyDirPath = keyDirPath
 
 	if len(certDirPath) == 0 {
 		return errors.New("invalid certificate directory path - empty")
 	}
-	conf.certDirPath = certDirPath
+	conf.CertDirPath = certDirPath
 
 	if len(encAlgo) == 0 {
 		return errors.New("invalid encryption algorithm - empty")
 	} else if encAlgo = strings.ToUpper(encAlgo); encAlgo != "AES-CTR" {
 		return errors.New("invalid encryption algorithm - not supported")
 	}
-	conf.encAlgo = encAlgo
+	conf.EncAlgo = encAlgo
 
 	if len(sigAlgo) == 0 {
 		return errors.New("invalid signature algorithm - empty")
 	} else if sigAlgo = strings.ToUpper(sigAlgo); sigAlgo != "ECDSA" {
 		return errors.New("invalid signature algorithm - not supported")
 	}
-	conf.sigAlgo = sigAlgo
+	conf.SigAlgo = sigAlgo
 
 	if len(kdf) == 0 {
 		errors.New("invalid key derivation function - empty")
 	} else if kdf = strings.ToLower(kdf); kdf != "scrypt" && kdf != "bcrypt" && kdf != "pbkdf2" {
 		return errors.New("invalid key derivation function - not supported")
 	}
-	conf.kdf = kdf
+	conf.Kdf = kdf
 
 	if len(kdfParams) == 0 {
 		return errors.New("invalid key derivation function parameters - empty")
 	}
-	conf.kdfParams = kdfParams
+	conf.KdfParams = kdfParams
 
 	switch secLv {
 	case 112:
@@ -107,47 +107,47 @@ func (conf *Config) initConfig(secLv int, keyDirPath, certDirPath, encAlgo, sigA
 	default:
 		return errors.New("invalid security level - not supported")
 	}
-	conf.secLv = secLv
+	conf.SecLv = secLv
 
 	return nil
 }
 
 func (conf *Config) initDefaultConfig() {
-	conf.secLv = 192
-	conf.keyDirPath = TestKeyDir
-	conf.certDirPath = TestCertDir
-	conf.kdf = "scrypt"
-	conf.sigAlgo = "ECDSA"
-	conf.encAlgo = "AES-CTR"
-	conf.kdfParams = DefaultScrpytParams
+	conf.SecLv = 192
+	conf.KeyDirPath = TestKeyDir
+	conf.CertDirPath = TestCertDir
+	conf.Kdf = "scrypt"
+	conf.SigAlgo = "ECDSA"
+	conf.EncAlgo = "AES-CTR"
+	conf.KdfParams = DefaultScrpytParams
 	conf.initBySecLv192()
 }
 
 // initBySecLv112 sets hash type, elliptic curve type, key length for encryption corresponding to 112bits of security level.
 func (conf *Config) initBySecLv112() {
-	conf.hashOpt = SHA224
-	conf.curveOpt = SECP224R1
-	conf.encKeyLength = int(112 / 8)
+	conf.HashOpt = SHA224
+	conf.CurveOpt = SECP224R1
+	conf.EncKeyLength = int(112 / 8)
 }
 
 // initBySecLv128 sets hash type, elliptic curve type, key length for encryption corresponding to 128bits of security level.
 func (conf *Config) initBySecLv128() {
-	conf.hashOpt = SHA256
-	conf.curveOpt = SECP256R1
-	conf.encKeyLength = int(128 / 8)
+	conf.HashOpt = SHA256
+	conf.CurveOpt = SECP256R1
+	conf.EncKeyLength = int(128 / 8)
 }
 
 // initBySecLv192 sets hash type, elliptic curve type, key length for encryption corresponding to 192bits of security level.
 func (conf *Config) initBySecLv192() {
-	conf.hashOpt = SHA384
-	conf.curveOpt = SECP384R1
-	conf.encKeyLength = int(192 / 8)
+	conf.HashOpt = SHA384
+	conf.CurveOpt = SECP384R1
+	conf.EncKeyLength = int(192 / 8)
 }
 
 // initBySecLv256 sets hash type, elliptic curve type, key length for encryption corresponding to 256bits of security level.
 func (conf *Config) initBySecLv256() {
-	conf.hashOpt = SHA512
-	conf.curveOpt = SECP521R1
-	conf.encKeyLength = int(256 / 8)
+	conf.HashOpt = SHA512
+	conf.CurveOpt = SECP521R1
+	conf.EncKeyLength = int(256 / 8)
 }
 

--- a/config.go
+++ b/config.go
@@ -119,10 +119,7 @@ func (conf *Config) initDefaultConfig() {
 	conf.kdf = "scrypt"
 	conf.sigAlgo = "ECDSA"
 	conf.encAlgo = "AES-CTR"
-	conf.kdfParams = make(map[string]string, 3)
-	conf.kdfParams["n"] = ScryptN
-	conf.kdfParams["r"] = ScryptR
-	conf.kdfParams["p"] = ScryptP
+	conf.kdfParams = DefaultScrpytParams
 	conf.initBySecLv192()
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -25,10 +25,7 @@ import (
 
 
 func TestNewConfig(t *testing.T) {
-	kdfParams := make(map[string]string, 3)
-	kdfParams["n"] = heimdall.ScryptN
-	kdfParams["r"] = heimdall.ScryptR
-	kdfParams["p"] = heimdall.ScryptP
+	kdfParams := heimdall.DefaultScrpytParams
 	conf, err := heimdall.NewConfig(192, heimdall.TestKeyDir, heimdall.TestCertDir, "AES-CTR", "ECDSA", "scrypt", kdfParams)
 	assert.NoError(t, err)
 	assert.NotNil(t, conf)

--- a/curveOpts_test.go
+++ b/curveOpts_test.go
@@ -15,46 +15,47 @@
  *
  */
 
-package heimdall
+package heimdall_test
 
 import (
 	"testing"
 	"github.com/stretchr/testify/assert"
 	"crypto/elliptic"
+	"github.com/it-chain/heimdall"
 )
 
 
 func TestCurveOpts_KeySize(t *testing.T) {
-	keySize := TestCurveOpt.KeySize()
+	keySize := heimdall.TestCurveOpt.KeySize()
 	assert.NotNil(t, keySize)
 }
 
 func TestCurveOpts_ValidCheck(t *testing.T) {
-	validBool := TestCurveOpt.ValidCheck()
+	validBool := heimdall.TestCurveOpt.ValidCheck()
 	assert.True(t, validBool)
 }
 
 func TestCurveOpts_String(t *testing.T) {
-	curveOptStr := TestCurveOpt.String()
+	curveOptStr := heimdall.TestCurveOpt.String()
 	assert.NotNil(t, curveOptStr)
 	assert.Equal(t, curveOptStr, "secp384r1")
 }
 
 func TestCurveOpts_CurveOptToCurve(t *testing.T) {
-	curve := TestCurveOpt.CurveOptToCurve()
+	curve := heimdall.TestCurveOpt.CurveOptToCurve()
 	assert.NotNil(t, curve)
 	assert.Equal(t, curve, elliptic.P384())
 }
 
 func TestStringToCurveOpt(t *testing.T) {
-	curveOpt := StringToCurveOpt("secp384r1")
-	assert.NotEqual(t, curveOpt, UNKNOWN)
-	assert.Equal(t, curveOpt, SECP384R1)
+	curveOpt := heimdall.StringToCurveOpt("secp384r1")
+	assert.NotEqual(t, curveOpt, heimdall.UNKNOWN)
+	assert.Equal(t, curveOpt, heimdall.SECP384R1)
 }
 
 func TestCurveToCurveOpt(t *testing.T) {
 	curve := elliptic.P384()
-	curveOpt := CurveToCurveOpt(curve)
-	assert.NotEqual(t, curveOpt, UNKNOWN)
-	assert.Equal(t, curveOpt, SECP384R1)
+	curveOpt := heimdall.CurveToCurveOpt(curve)
+	assert.NotEqual(t, curveOpt, heimdall.UNKNOWN)
+	assert.Equal(t, curveOpt, heimdall.SECP384R1)
 }

--- a/definition.go
+++ b/definition.go
@@ -22,7 +22,6 @@ package heimdall
 import (
 	"os"
 	"path/filepath"
-	"encoding/hex"
 	"crypto/x509"
 	"math/big"
 	"crypto/x509/pkix"
@@ -53,16 +52,14 @@ const TestHashOpt = SHA512
 var TestConf = NewDefaultConfig()
 // Note: salt have to be unique, so do not use this for real implementation.
 var TestSalt = []byte{0xc8, 0x28, 0xf2, 0x58, 0xa7, 0x6a, 0xad, 0x7b}
-var TestScrpytParams = map[string]string{
+// Default scrypt Parameters
+var DefaultScrpytParams = map[string]string{
 	// N should highest power of 2 that key derived in 100ms.
-	"n" : ScryptN,
+	"n" : "32768", // 1 << 15 (2^15)
 	// R(blocksize parameter) : fine-tune sequential memory read size and performance. (8 is commonly used)
-	"r" : ScryptR,
+	"r" : "8",
 	// P(Parallelization parameter) : a positive integer satisfying p ≤ (232− 1) * hLen / MFLen.
-	"p" : ScryptP,
-	// keyLen : Desired length of key in bytes
-	"keyLen" : ScryptKeyLen,
-	"salt" : hex.EncodeToString([]byte("saltsalt")),
+	"p" : "32" ,
 }
 
 var TestRootCertTemplate = x509.Certificate{

--- a/definition.go
+++ b/definition.go
@@ -30,7 +30,7 @@ import (
 
 
 // Key ID prefix
-const keyIDPrefix = "IT"
+const KeyIDPrefix = "IT"
 
 // KDF functions
 const SCRYPT = "scrypt"

--- a/hash_test.go
+++ b/hash_test.go
@@ -15,26 +15,27 @@
  *
  */
 
-package heimdall
+package heimdall_test
 
 import (
 	"testing"
 	"github.com/stretchr/testify/assert"
+	"github.com/it-chain/heimdall"
 )
 
 func TestHashManager_Hash(t *testing.T) {
 	rawData := []byte("This data will be hashed by hashManager")
 
 	// normal case
-	digest, err := Hash(rawData, nil, SHA512)
+	digest, err := heimdall.Hash(rawData, nil, heimdall.SHA512)
 	assert.NoError(t, err)
 	assert.NotNil(t, digest)
 
 	// compare between hashed data by the same hash function
-	anotherDigest, err := Hash(rawData, nil, SHA512)
+	anotherDigest, err := heimdall.Hash(rawData, nil, heimdall.SHA512)
 	assert.Equal(t, digest, anotherDigest)
 
 	// compare between hashed data by the different hash function
-	anotherDigest, err = Hash(rawData, nil, SHA256)
+	anotherDigest, err = heimdall.Hash(rawData, nil, heimdall.SHA256)
 	assert.NotEqual(t, digest, anotherDigest)
 }

--- a/keyDerivation_test.go
+++ b/keyDerivation_test.go
@@ -15,15 +15,16 @@
  *
  */
 
-package heimdall
+package heimdall_test
 
 import (
 	"testing"
 	"github.com/stretchr/testify/assert"
+	"github.com/it-chain/heimdall"
 )
 
 func TestDeriveKeyFromPwd(t *testing.T) {
-	dKey, err := DeriveKeyFromPwd(TestConf.kdf, []byte("password"), TestSalt, TestConf.encKeyLength, TestConf.kdfParams)
+	dKey, err := heimdall.DeriveKeyFromPwd(heimdall.TestConf.Kdf, []byte("password"), heimdall.TestSalt, heimdall.TestConf.EncKeyLength, heimdall.TestConf.KdfParams)
 	assert.NoError(t, err)
 	assert.NotNil(t, dKey)
 }

--- a/keyEncryption_test.go
+++ b/keyEncryption_test.go
@@ -15,29 +15,30 @@
  *
  */
 
-package heimdall
+package heimdall_test
 
 import (
 	"testing"
 	"github.com/stretchr/testify/assert"
+	"github.com/it-chain/heimdall"
 )
 
 func TestEncryptPriKey(t *testing.T) {
-	pri, _ := GenerateKey(TestCurveOpt)
-	dKey, _ := DeriveKeyFromPwd(TestConf.kdf, []byte("password"), TestSalt, TestConf.encKeyLength, TestConf.kdfParams)
+	pri, _ := heimdall.GenerateKey(heimdall.TestCurveOpt)
+	dKey, _ := heimdall.DeriveKeyFromPwd(heimdall.TestConf.Kdf, []byte("password"), heimdall.TestSalt, heimdall.TestConf.EncKeyLength, heimdall.TestConf.KdfParams)
 
-	encryptedKey, err := EncryptPriKey(pri, dKey)
+	encryptedKey, err := heimdall.EncryptPriKey(pri, dKey)
 	assert.NoError(t, err)
 	assert.NotNil(t, encryptedKey)
 }
 
 func TestDecryptPriKey(t *testing.T) {
-	pri, _ := GenerateKey(TestCurveOpt)
-	dKey, _ := DeriveKeyFromPwd(TestConf.kdf, []byte("password"), TestSalt, TestConf.encKeyLength, TestConf.kdfParams)
+	pri, _ := heimdall.GenerateKey(heimdall.TestCurveOpt)
+	dKey, _ := heimdall.DeriveKeyFromPwd(heimdall.TestConf.Kdf, []byte("password"), heimdall.TestSalt, heimdall.TestConf.EncKeyLength, heimdall.TestConf.KdfParams)
 
-	encryptedKey, _ := EncryptPriKey(pri, dKey)
+	encryptedKey, _ := heimdall.EncryptPriKey(pri, dKey)
 
-	decryptedKey, err := DecryptPriKey(encryptedKey, dKey, TestCurveOpt)
+	decryptedKey, err := heimdall.DecryptPriKey(encryptedKey, dKey, heimdall.TestCurveOpt)
 	assert.NotNil(t, decryptedKey)
 	assert.NoError(t, err)
 	assert.EqualValues(t, pri, decryptedKey)

--- a/key_test.go
+++ b/key_test.go
@@ -15,112 +15,113 @@
  *
  */
 
-package heimdall
+package heimdall_test
 
 import (
 	"testing"
 	"github.com/stretchr/testify/assert"
 	"encoding/hex"
 	"strings"
+	"github.com/it-chain/heimdall"
 )
 
 func TestGenerateKey(t *testing.T) {
-	pri, err := GenerateKey(TestCurveOpt)
+	pri, err := heimdall.GenerateKey(heimdall.TestCurveOpt)
 	assert.NoError(t, err)
 	assert.NotNil(t, pri)
 }
 
 func TestPriKeyToBytes(t *testing.T) {
-	pri, _ := GenerateKey(TestCurveOpt)
-	keyBytes := PriKeyToBytes(pri)
+	pri, _ := heimdall.GenerateKey(heimdall.TestCurveOpt)
+	keyBytes := heimdall.PriKeyToBytes(pri)
 	assert.NotNil(t, keyBytes)
 }
 
 func TestBytesToPriKey(t *testing.T) {
-	pri, _ := GenerateKey(TestCurveOpt)
-	keyBytes := PriKeyToBytes(pri)
+	pri, _ := heimdall.GenerateKey(heimdall.TestCurveOpt)
+	keyBytes := heimdall.PriKeyToBytes(pri)
 	assert.NotNil(t, keyBytes)
 
-	recPri, err := BytesToPriKey(keyBytes, TestCurveOpt)
+	recPri, err := heimdall.BytesToPriKey(keyBytes, heimdall.TestCurveOpt)
 	assert.NoError(t, err)
 	assert.NotNil(t, recPri)
 	assert.EqualValues(t, pri, recPri)
 }
 
 func TestPubKeyToBytes(t *testing.T) {
-	pri, _ := GenerateKey(TestCurveOpt)
-	keyBytes := PubKeyToBytes(&pri.PublicKey)
+	pri, _ := heimdall.GenerateKey(heimdall.TestCurveOpt)
+	keyBytes := heimdall.PubKeyToBytes(&pri.PublicKey)
 	assert.NotNil(t, keyBytes)
 }
 
 func TestBytesToPubKey(t *testing.T) {
-	pri, _ := GenerateKey(TestCurveOpt)
-	keyBytes := PubKeyToBytes(&pri.PublicKey)
+	pri, _ := heimdall.GenerateKey(heimdall.TestCurveOpt)
+	keyBytes := heimdall.PubKeyToBytes(&pri.PublicKey)
 	assert.NotNil(t, keyBytes)
 
-	pub, err := BytesToPubKey(keyBytes, TestCurveOpt)
+	pub, err := heimdall.BytesToPubKey(keyBytes, heimdall.TestCurveOpt)
 	assert.NoError(t, err)
 	assert.NotNil(t, pub)
 	assert.EqualValues(t, pub, &pri.PublicKey)
 }
 
 func TestSKIFromPubKey(t *testing.T) {
-	pri, _ := GenerateKey(TestCurveOpt)
-	ski := SKIFromPubKey(&pri.PublicKey)
+	pri, _ := heimdall.GenerateKey(heimdall.TestCurveOpt)
+	ski := heimdall.SKIFromPubKey(&pri.PublicKey)
 	assert.NotNil(t, ski)
 }
 
 func TestPubKeyToKeyID(t *testing.T) {
-	pri, _ := GenerateKey(TestCurveOpt)
-	keyId := PubKeyToKeyID(&pri.PublicKey)
+	pri, _ := heimdall.GenerateKey(heimdall.TestCurveOpt)
+	keyId := heimdall.PubKeyToKeyID(&pri.PublicKey)
 	assert.NotNil(t, keyId)
-	assert.True(t, strings.HasPrefix(keyId, keyIDPrefix))
+	assert.True(t, strings.HasPrefix(keyId, heimdall.KeyIDPrefix))
 }
 
 func TestSKIToKeyID(t *testing.T) {
-	pri, _ := GenerateKey(TestCurveOpt)
-	ski := SKIFromPubKey(&pri.PublicKey)
-	keyId := SKIToKeyID(ski)
+	pri, _ := heimdall.GenerateKey(heimdall.TestCurveOpt)
+	ski := heimdall.SKIFromPubKey(&pri.PublicKey)
+	keyId := heimdall.SKIToKeyID(ski)
 	assert.NotNil(t, keyId)
-	assert.True(t, strings.HasPrefix(keyId, keyIDPrefix))
+	assert.True(t, strings.HasPrefix(keyId, heimdall.KeyIDPrefix))
 }
 
 func TestSKIFromKeyID(t *testing.T) {
-	pri, _ := GenerateKey(TestCurveOpt)
-	keyId := PubKeyToKeyID(&pri.PublicKey)
-	ski := SKIFromKeyID(keyId)
+	pri, _ := heimdall.GenerateKey(heimdall.TestCurveOpt)
+	keyId := heimdall.PubKeyToKeyID(&pri.PublicKey)
+	ski := heimdall.SKIFromKeyID(keyId)
 	assert.NotNil(t, ski)
 }
 
 func TestRemoveKeyMem(t *testing.T) {
-	pri, _ := GenerateKey(TestCurveOpt)
+	pri, _ := heimdall.GenerateKey(heimdall.TestCurveOpt)
 	prevValue := pri.D
-	RemoveKeyMem(pri)
+	heimdall.RemoveKeyMem(pri)
 	assert.NotEqual(t, pri.D, prevValue)
 	assert.Equal(t, pri.D.Int64(), int64(0))
 }
 
 func TestSKIValidCheck(t *testing.T) {
-	pri, _ := GenerateKey(TestCurveOpt)
-	ski := SKIFromPubKey(&pri.PublicKey)
-	keyId := SKIToKeyID(ski)
+	pri, _ := heimdall.GenerateKey(heimdall.TestCurveOpt)
+	ski := heimdall.SKIFromPubKey(&pri.PublicKey)
+	keyId := heimdall.SKIToKeyID(ski)
 
-	err := SKIValidCheck(keyId, hex.EncodeToString(ski))
+	err := heimdall.SKIValidCheck(keyId, hex.EncodeToString(ski))
 	assert.NoError(t, err)
 
-	err = SKIValidCheck(keyId, hex.EncodeToString([]byte("fake ski")))
+	err = heimdall.SKIValidCheck(keyId, hex.EncodeToString([]byte("fake ski")))
 	assert.Error(t, err)
 }
 
 func TestKeyIDPrefixCheck(t *testing.T) {
-	pri, _ := GenerateKey(TestCurveOpt)
-	ski := SKIFromPubKey(&pri.PublicKey)
-	keyId := SKIToKeyID(ski)
+	pri, _ := heimdall.GenerateKey(heimdall.TestCurveOpt)
+	ski := heimdall.SKIFromPubKey(&pri.PublicKey)
+	keyId := heimdall.SKIToKeyID(ski)
 	fakeKeyId := "fake" + keyId
 
-	err := KeyIDPrefixCheck(keyId)
+	err := heimdall.KeyIDPrefixCheck(keyId)
 	assert.NoError(t, err)
 
-	err = KeyIDPrefixCheck(fakeKeyId)
+	err = heimdall.KeyIDPrefixCheck(fakeKeyId)
 	assert.Error(t, err)
 }

--- a/keystore_test.go
+++ b/keystore_test.go
@@ -15,41 +15,42 @@
  *
  */
 
-package heimdall
+package heimdall_test
 
 import (
 	"testing"
 	"github.com/stretchr/testify/assert"
 	"os"
+	"github.com/it-chain/heimdall"
 )
 
 func TestNewKeyStore(t *testing.T) {
-	ks, err := NewKeyStore(TestConf.keyDirPath, TestConf.kdf, TestConf.kdfParams, TestConf.encAlgo, TestConf.encKeyLength)
+	ks, err := heimdall.NewKeyStore(heimdall.TestConf.KeyDirPath, heimdall.TestConf.Kdf, heimdall.TestConf.KdfParams, heimdall.TestConf.EncAlgo, heimdall.TestConf.EncKeyLength)
 	assert.NoError(t, err)
 	assert.NotNil(t, ks)
 }
 
 func TestKeystore_StoreKey(t *testing.T) {
-	pri, _ := GenerateKey(TestCurveOpt)
+	pri, _ := heimdall.GenerateKey(heimdall.TestCurveOpt)
 
-	ks, _ := NewKeyStore(TestConf.keyDirPath, TestConf.kdf, TestConf.kdfParams, TestConf.encAlgo, TestConf.encKeyLength)
+	ks, _ := heimdall.NewKeyStore(heimdall.TestConf.KeyDirPath, heimdall.TestConf.Kdf, heimdall.TestConf.KdfParams, heimdall.TestConf.EncAlgo, heimdall.TestConf.EncKeyLength)
 	err := ks.StoreKey(pri, "password")
 	assert.NoError(t, err)
 
-	defer os.RemoveAll(TestKeyDir)
+	defer os.RemoveAll(heimdall.TestKeyDir)
 }
 
 func TestKeystore_LoadKey(t *testing.T) {
-	pri, _ := GenerateKey(TestConf.curveOpt)
+	pri, _ := heimdall.GenerateKey(heimdall.TestConf.CurveOpt)
 
-	ks, _ := NewKeyStore(TestConf.keyDirPath, TestConf.kdf, TestConf.kdfParams, TestConf.encAlgo, TestConf.encKeyLength)
+	ks, _ := heimdall.NewKeyStore(heimdall.TestConf.KeyDirPath, heimdall.TestConf.Kdf, heimdall.TestConf.KdfParams, heimdall.TestConf.EncAlgo, heimdall.TestConf.EncKeyLength)
 	_ = ks.StoreKey(pri, "password")
 
-	keyId := PubKeyToKeyID(&pri.PublicKey)
+	keyId := heimdall.PubKeyToKeyID(&pri.PublicKey)
 	loadedPri, err := ks.LoadKey(keyId, "password")
 	assert.NoError(t, err)
 	assert.NotNil(t, loadedPri)
 	assert.EqualValues(t, loadedPri, pri)
 
-	defer os.RemoveAll(TestKeyDir)
+	defer os.RemoveAll(heimdall.TestKeyDir)
 }


### PR DESCRIPTION
issue #61 
test pacakge 변경 (heimdall -> heimdall_test)
변경 도중에 export가 필요한 변수들이 있는게 발견되서 config 구조체 멤버 변수들과 definition에서 key id prefix변수의 첫글자를 대문자로 변경했습니다.