### PR TITLE
[issue #74] intermediate pool empty check if문 제거

### DIFF
--- a/certificate.go
+++ b/certificate.go
@@ -247,10 +247,6 @@ func (cs *CertStore) makeIntermediatesPool() (intermediatesPool *x509.CertPool, 
 		}
 	}
 
-	if len(intermediatesPool.Subjects()) == 0 {
-		return nil, errors.New("no root certificate in certificate store directory")
-	}
-
 	return intermediatesPool, nil
 }
 


### PR DESCRIPTION
issue #74 - remove if statement for empty intermediate pool for verifying cert chain

---- 아래는 issue #74 본문입니다.

intermediate CA 인증서는 chain에 꼭 있어야하는 인증서가 아니므로 if문으로 강제해서 에러 발생시키면 root CA에게 직접 받은 정당한 인증서에서 에러 발생

ex) 현재는..
rootCA -> IntermediateCA -> client (정상)
rootCA -> client (에러) -> 이것도 정상이어야함!!

그러므로 cert chain 검증 시 intermediate cert pool의 길이가 0이면 에러 발생시키는 if문 제거해야함!!